### PR TITLE
Pull remaining update from ecustools

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: prxytools
 Title: An R package of tools to assist with proxy analyses
-Version: 0.1.1
+Version: 0.1.2
 Author:
   Thomas Muench [aut, cre],
   Andrew Dolman [aut],

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# prxytools 0.1.2
+
+* Allow variable offsets of "reservoir ages" in radiocarbon age calibration with
+  `CalibrateAge()` (pulled from 'ecustools'
+  [`dev-CalibrateAge`](https://github.com/EarthSystemDiagnostics/ecustools/tree/dev-CalibrateAge)
+  branch as of 2021-01-18; see
+  [5b8379e](https://github.com/EarthSystemDiagnostics/ecustools/commit/5b8379e64632cd48fcc41a51cec916869aa49a70)).
+
 # prxytools 0.1.1
 
 * Improved function documentations.
@@ -8,4 +16,6 @@
 
 * Initial package version with number and scope of the functions incl. their
   documentation identical to their original versions in deprecated package
-  'ecustools' which they were a part of.
+  'ecustools' which they were a part of ('ecustools'
+  [`main`](https://github.com/EarthSystemDiagnostics/ecustools/tree/master)
+  branch as of 2020-11-20).

--- a/R/calibration-functions.R
+++ b/R/calibration-functions.R
@@ -149,9 +149,9 @@ CalibrateAge <- function(df, age.14C = "age.14C",
                                         "intcal20", "marine20", "shcal20",
                                         "normal"))
 
-  if (is.null(offset)){
+  if (is.null(offset)) {
     df$offset <- 0
-  } else{
+  } else {
     df$offset <- df[[offset]]
   }
 

--- a/R/calibration-functions.R
+++ b/R/calibration-functions.R
@@ -108,7 +108,9 @@ CalcifTemp <- function(d18Oc, d18Ow) {
 #' @param return.type character; signal the amount of returned information:
 #'   return only the ammended dataframe (\code{"df"}) or additionally the list
 #'   of PDFs (\code{"lst"}); defaults to (\code{"df"}).
-#' @param offset numeric; optional offset applied to all 14C ages; defaults to 0.
+#' @param offset character; name of an optional additional column in \code{df}
+#'   supplying a variable offset applied to all 14C ages; the default
+#'   \code{NULL} means to apply no offset.
 #' @return A dataframe or list.
 #' @author Andrew Dolman
 #' @examples
@@ -140,16 +142,22 @@ CalcifTemp <- function(d18Oc, d18Ow) {
 CalibrateAge <- function(df, age.14C = "age.14C",
                          age.14C.se = "age.14C.se",
                          curve = "intcal20",
-                         return.type = "df", offset = 0){
+                         return.type = "df", offset = NULL) {
 
   return.type <- match.arg(return.type, choices = c("df", "lst"))
   curve <- match.arg(curve, choices = c("intcal13", "shcal13", "marine13",
                                         "intcal20", "marine20", "shcal20",
                                         "normal"))
 
-  cal.ages <- lapply(1:nrow(df), function(x) {
+  if (is.null(offset)){
+    df$offset <- 0
+  } else{
+    df$offset <- df[[offset]]
+  }
+
+  cal.ages <- lapply(1 : nrow(df), function(x) {
     tryCatch(Bchron::BchronCalibrate(
-      ages = df[[age.14C]][x] + offset,
+      ages = df[[age.14C]][x] + df[["offset"]][x],
       ageSds = df[[age.14C.se]][x],
       calCurves = curve,
       ids = x),

--- a/man/CalibrateAge.Rd
+++ b/man/CalibrateAge.Rd
@@ -10,7 +10,7 @@ CalibrateAge(
   age.14C.se = "age.14C.se",
   curve = "intcal20",
   return.type = "df",
-  offset = 0
+  offset = NULL
 )
 }
 \arguments{
@@ -28,7 +28,9 @@ error 14C age uncertainty; defaults to \code{"age.14C.se"}.}
 return only the ammended dataframe (\code{"df"}) or additionally the list
 of PDFs (\code{"lst"}); defaults to (\code{"df"}).}
 
-\item{offset}{numeric; optional offset applied to all 14C ages; defaults to 0.}
+\item{offset}{character; name of an optional additional column in \code{df}
+supplying a variable offset applied to all 14C ages; the default
+\code{NULL} means to apply no offset.}
 }
 \value{
 A dataframe or list.


### PR DESCRIPTION
This PR introduces the changes made by [5b8379e](https://github.com/EarthSystemDiagnostics/ecustools/commit/5b8379e64632cd48fcc41a51cec916869aa49a70) on the 'ecustools' [`dev-CalibrateAge`](https://github.com/EarthSystemDiagnostics/ecustools/tree/dev-CalibrateAge) branch as of 2021-01-18, which allow variable offsets of "reservoir ages" in radiocarbon age calibration with`CalibrateAge()`. With this, the migration from 'ecustools' to 'prxytools' is finished.