### PR TITLE
Bin average from index positions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: prxytools
 Title: An R package of tools to assist with proxy analyses
-Version: 0.1.2
+Version: 0.2.0
 Author:
   Thomas Muench [aut, cre],
   Andrew Dolman [aut],
@@ -22,3 +22,6 @@ LazyData: true
 RoxygenNote: 7.1.1
 Remotes:
     earthsystemdiagnostics/stattools
+Suggests:
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	- Rscript -e "devtools::test()"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# prxytools 0.2.0
+
+* New function `AverageByIndex()` added which allows to calculate bin averages
+  defined by vector index positions.
+
 # prxytools 0.1.2
 
 * Allow variable offsets of "reservoir ages" in radiocarbon age calibration with

--- a/R/bin-averaging.R
+++ b/R/bin-averaging.R
@@ -1,0 +1,61 @@
+#' Bin average from index positions
+#'
+#' Calculate bin averages defined by vector index positions.
+#'
+#' Averaging bins are defined consecutively from the first index position
+#' to the index position one before the next index, i.e., closed on the left
+#' and open on the right (the right end of the first bin does not overlap with
+#' the left end of the second bin, and so on).
+#'
+#' But note that the final bin is treated separately: if the last index
+#' coincides with the last data point of \code{x}, this point _is_ included in
+#' the last bin average, else the bin is treated analogously to the other bins
+#' (see examples).
+#'
+#' @param x numeric vector for which to compute bin averages according to the
+#' indices given in \code{ind}.
+#' @param ind numeric vector of index positions specifying the binning windows
+#'   to average over, see details.
+#' @param na.rm a logical value indicating whether ‘NA’ values should be
+#' stripped before the computation proceeds. Defaults to \code{TRUE}.
+#' @return a numeric vector of length \code{length(ind) - 1} with the mean
+#' values of each bin from the break points defined by \code{ind}.
+#' @author Thomas Münch
+#' @examples
+#' x <- rnorm(20)
+#'
+#' # final bin includes final data point:
+#' AverageByIndex(x, ind = c(1, 7, 13, 17, 20))
+#' # final index is not final data point:
+#' AverageByIndex(x, ind = c(1, 7, 13, 17))
+#' @export
+AverageByIndex <- function(x, ind, na.rm = TRUE) {
+
+  n <- length(ind)
+
+  # check validity of indices
+  if (any(ind < 1)) {
+    stop("Indices all must be >= 1.")
+  }
+  if (min(diff(ind)) < 0) {
+    stop("Indices must be monotonically increasing.")
+  }
+  if (any(ind > length(x))) {
+    stop("Index out of data index range.")
+  }
+
+  # if final index is final data point, include it in the last bin average
+  if (ind[n] == length(x)) {
+    ind[n] <- ind[n] + 1
+  }
+  
+  avg <- vector()
+  for (i in (1 : (n - 1))) {
+
+    # define bins closed on the left and open on the right
+    range <- ind[i] : (ind[i + 1] - 1)
+    avg[i] <- mean(x[range], na.rm = na.rm)
+  }
+  
+  return(avg)
+}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(prxytools)
+
+test_check("prxytools")

--- a/tests/testthat/test-bin-averaging.R
+++ b/tests/testthat/test-bin-averaging.R
@@ -1,0 +1,25 @@
+test_that("Bin averaging by indices works", {
+
+  x <- 1 : 10
+  
+  expect_error(AverageByIndex(x, ind = c(-1, 5, 8)),
+               "Indices all must be >= 1.")
+  expect_error(AverageByIndex(x, ind = c(0, 5, 8)),
+               "Indices all must be >= 1.")
+
+  expect_error(AverageByIndex(x, ind = c(5, 3, 8)),
+               "Indices must be monotonically increasing.")
+
+  expect_error(AverageByIndex(x, ind = c(1, 5, 13)),
+               "Index out of data index range.")
+
+  expect_equal(AverageByIndex(x, ind = c(1, 4, 7, 9)), c(2, 5, 7.5))
+  expect_equal(AverageByIndex(x, ind = c(1, 4, 7, 10)), c(2, 5, 8.5))
+  expect_equal(AverageByIndex(x, ind = c(4, 7)), 5)
+
+  x <- c(NA, x[-1])
+  expect_equal(AverageByIndex(x, ind = c(1, 4, 7, 9)), c(2.5, 5, 7.5))
+  expect_equal(AverageByIndex(x, ind = c(1, 4, 7, 9), na.rm = FALSE),
+               c(NA, 5, 7.5))
+
+})


### PR DESCRIPTION
The new function `AverageByIndex()` allows to calculate bin averages defined by vector index positions.